### PR TITLE
Support custom s3 providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@ docker run \
     cron "* * * * *"
 ```
 
+### Custom s3 endpoint
+
+```shell
+docker run \
+    -v /path/to/database.db:/data/sqlite3.db \
+    -e S3_BUCKET=mybackupbucket \
+    -e AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE \
+    -e AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \
+    -e AWS_DEFAULT_REGION=us-east-1 \
+    -e ENDPOINT_URL=https://play.minio.com:9000 \
+    jacobtomlinson/sqlite-to-s3:latest \
+    cron "* * * * *"
+```
+
 ### Run backup
 
 ```shell
@@ -66,3 +80,4 @@ docker run \
 | `AWS_DEFAULT_REGION`   | AWS Default Region | `us-west-2`    | `us-west-1`   | Yes |
 | `DATABASE_PATH` | Path of database to be backed up (within the container)   | `/myvolume/mydb.db` | `/data/sqlite3.db`   | Yes |
 | `BACKUP_PATH` | Path to write the backup (within the container)  | `/myvolume/mybackup.db` | `${DATABASE_PATH}.bak`   | Yes |
+| `ENDPOINT_URL` | Url to the s3 service endpoint  | `https://play.minio.com:9000` | None   | Yes |

--- a/sqlite-to-s3.sh
+++ b/sqlite-to-s3.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+shopt -s expand_aliases
+
 # Check and set missing environment vars
 : ${S3_BUCKET:?"S3_BUCKET env variable is required"}
 if [[ -z ${S3_KEY_PREFIX} ]]; then
@@ -12,6 +14,11 @@ else
   fi
 fi
 echo $S3_KEY_PREFIX
+
+if [[ -n ${ENDPOINT_URL} ]]; then
+  alias aws="aws --endpoint-url ${ENDPOINT_URL}"
+fi
+
 export DATABASE_PATH=${DATABASE_PATH:-/data/sqlite3.db}
 export BACKUP_PATH=${BACKUP_PATH:-${DATABASE_PATH}.bak}
 export DATETIME=$(date "+%Y%m%d%H%M%S")


### PR DESCRIPTION
Allow to set `--endpoint-url` for `aws` cli tool to support custom s3 providers ex. Minio.
If you want to connect to custom s3 provider then pass `ENDPOINT_URL` var to your docker environment:

```shell
docker run \
    -v /path/to/database.db:/data/sqlite3.db \
    -e S3_BUCKET=mybackupbucket \
    -e AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE \
    -e AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \
    -e AWS_DEFAULT_REGION=us-east-1 \
    -e ENDPOINT_URL=https://play.minio.io:9000 \
    jacobtomlinson/sqlite-to-s3:latest
```